### PR TITLE
fix: Update azuremonitor module source following rename

### DIFF
--- a/module.tf
+++ b/module.tf
@@ -25,7 +25,7 @@ resource "azurerm_bastion_host" "bastion" {
 #bastion logging
 module "bastion_diag" {
   count                      = var.azure_monitor != null ? 1 : 0
-  source                     = "github.com/rodmhgl/AzureMonitorOnboarding?ref=v1.0.0"
+  source                     = "github.com/rodmhgl/terraform-azurerm-azuremonitoronboarding?ref=v1.0.0"
   resource_name              = azurerm_bastion_host.bastion.name
   resource_id                = azurerm_bastion_host.bastion.id
   log_analytics_workspace_id = var.azure_monitor.law_out.id


### PR DESCRIPTION
- the source for bastion_diag was renamed - updated module due to breaking bug. 